### PR TITLE
ci: add GitHub Actions workflow for build, format, and tidy checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/determinate-nix-action@v3
+      - name: Build project
+        run: nix develop --command bash -c "cmake -B build -S . && cmake --build build"
+      - name: Format check
+        run: nix develop --command cmake --build build --target format
+      - name: Clang-Tidy check
+        run: nix develop --command cmake --build build --target tidy


### PR DESCRIPTION
Adds a CI workflow that installs Determinate Nix and uses nix develop to build the project and run the custom CMake format and tidy targets. This ensures the code builds, is formatted, and passes clang-tidy checks via the devshell environment. Closes #15.