### PR TITLE
fix: prevent segfault when exiting pause menu

### DIFF
--- a/src/mon.c
+++ b/src/mon.c
@@ -41,9 +41,7 @@ Mon *createMon(char *name)
 {
     Mon *mon = malloc(sizeof(Mon));
     mon->name = malloc(strlen(name) + 1);
-    size_t nameLen = strlen(name);
-    memcpy((char *)mon->name, name, nameLen);
-    ((char *)mon->name)[nameLen] = '\0';
+    strcpy((char *)mon->name, name);
     mon->texture = malloc(sizeof(Texture2D));
     mon->hp = 100;
     // TODO: Initialize other values

--- a/src/pause.c
+++ b/src/pause.c
@@ -11,6 +11,7 @@ static void exitSelect(void)
 {
     pauseMenuEnd();
     CloseWindow();
+    exit(0);
 }
 static void creditsSelect(void) { return; }
 

--- a/src/pause.c
+++ b/src/pause.c
@@ -66,11 +66,10 @@ void pauseMenuDisplay(void)
         pauseMenu->prevItem(pauseMenu);
     }
     else if (IsKeyPressed(KEY_ENTER))
-        {
-    pauseMenu->items[pauseMenu->selectedItem].select();
-    return;
-
-                }
+    {
+        pauseMenu->items[pauseMenu->selectedItem].select();
+        return;
+    }
 
     MenuItem currentItem = pauseItems[pauseMenu->selectedItem];
     DrawRectangleLines(currentItem.posX - 10, currentItem.posY - 5, 300, 30, DARKGRAY);

--- a/src/pause.c
+++ b/src/pause.c
@@ -66,7 +66,11 @@ void pauseMenuDisplay(void)
         pauseMenu->prevItem(pauseMenu);
     }
     else if (IsKeyPressed(KEY_ENTER))
-        pauseMenu->items[pauseMenu->selectedItem].select();
+        {
+    pauseMenu->items[pauseMenu->selectedItem].select();
+    return;
+
+                }
 
     MenuItem currentItem = pauseItems[pauseMenu->selectedItem];
     DrawRectangleLines(currentItem.posX - 10, currentItem.posY - 5, 300, 30, DARKGRAY);


### PR DESCRIPTION
When the user selects 'EXIT' from the pause menu or closes the window, the pauseMenu pointer is freed. Continuing to use pauseMenu->selectedItem after freeing causes a segmentation fault. This change calls the selected callback and returns immediately to avoid dereferencing a destroyed menu. Fixes #11.